### PR TITLE
Added RZero as attribute to MQ135 class and refactored a bit the libr…

### DIFF
--- a/MQ135.cpp
+++ b/MQ135.cpp
@@ -138,7 +138,7 @@ float MQ135::getStoredRZero() {
 */
 /**************************************************************************/
 float MQ135::getCorrectedRZero(float t, float h) {
-  return getCorrectedResistance(t, h) * getRZero();
+  return getCorrectedResistance(t, h) * pow((PARA/ATMOCO2), (1./PARB));
 }
 
 /**************************************************************************/

--- a/MQ135.cpp
+++ b/MQ135.cpp
@@ -11,6 +11,7 @@ the datasheet but the information there seems to be wrong.
 @section  HISTORY
 
 v1.0 - First release
+v1.1 - Added setter to RZero (A. Stoica - rstoica)
 */
 /**************************************************************************/
 
@@ -20,12 +21,19 @@ v1.0 - First release
 /*!
 @brief  Default constructor
 
+The RZero is initialized to a "common-sense" uncalibrated value of 76.63 kOhms. 
+This needs to be calibrated by the user prior to use the gas sensor.
+
 @param[in] pin  The analog input pin for the readout of the sensor
 */
 /**************************************************************************/
 
 MQ135::MQ135(uint8_t pin) {
   _pin = pin;
+  /// This value is the one the original author set in the define originally
+  /// and varies from sensor to sensor, so it needs calibration and so it 
+  /// has been encapsulated as a modifiable property rather than a hard coded value.
+  RZero = 225;
 }
 
 
@@ -78,7 +86,7 @@ float MQ135::getCorrectedResistance(float t, float h) {
 */
 /**************************************************************************/
 float MQ135::getPPM() {
-  return PARA * pow((getResistance()/RZERO), -PARB);
+  return PARA * pow((getResistance()/RZero), PARB);
 }
 
 /**************************************************************************/
@@ -93,7 +101,7 @@ float MQ135::getPPM() {
 */
 /**************************************************************************/
 float MQ135::getCorrectedPPM(float t, float h) {
-  return PARA * pow((getCorrectedResistance(t, h)/RZERO), -PARB);
+  return PARA * pow((getCorrectedResistance(t, h)/RZero), PARB);
 }
 
 /**************************************************************************/
@@ -104,7 +112,18 @@ float MQ135::getCorrectedPPM(float t, float h) {
 */
 /**************************************************************************/
 float MQ135::getRZero() {
-  return getResistance() * pow((ATMOCO2/PARA), (1./PARB));
+  return getResistance() * pow((PARA/ATMOCO2), (1./PARB));
+}
+
+/**************************************************************************/
+/*!
+@brief  Get the stored RZero resistance of this sensor instance.
+
+@return The sensor resistance RZero in kOhm
+*/
+/**************************************************************************/
+float MQ135::getStoredRZero() {
+  return RZero;
 }
 
 /**************************************************************************/
@@ -119,5 +138,18 @@ float MQ135::getRZero() {
 */
 /**************************************************************************/
 float MQ135::getCorrectedRZero(float t, float h) {
-  return getCorrectedResistance(t, h) * pow((ATMOCO2/PARA), (1./PARB));
+  return getCorrectedResistance(t, h) * getRZero();
+}
+
+/**************************************************************************/
+/*!
+@brief  Sets the resistance RZero property of the sensor for calibration purposes. 
+
+Ideally the user should call this method after calibration has taken place.
+
+@param[in] r The calculated RZero value in kOhm.
+*/
+/**************************************************************************/
+void MQ135::setRZero(float r) {
+  RZero = r;
 }

--- a/MQ135.h
+++ b/MQ135.h
@@ -11,6 +11,7 @@ the datasheet but the information there seems to be wrong.
 @section  HISTORY
 
 v1.0 - First release
+v1.1 - Added setter to RZero (A. Stoica - rstoica)
 */
 /**************************************************************************/
 #ifndef MQ135_H
@@ -23,11 +24,10 @@ v1.0 - First release
 
 /// The load resistance on the board
 #define RLOAD 10.0
-/// Calibration resistance at atmospheric CO2 level
-#define RZERO 76.63
+
 /// Parameters for calculating ppm of CO2 from sensor resistance
 #define PARA 116.6020682
-#define PARB 2.769034857
+#define PARB -2.769034857
 
 /// Parameters to model temperature and humidity dependence
 #define CORA 0.00035
@@ -36,11 +36,12 @@ v1.0 - First release
 #define CORD 0.0018
 
 /// Atmospheric CO2 level for calibration purposes
-#define ATMOCO2 397.13
+#define ATMOCO2 404.34 /// see at https://www.co2.earth/daily-co2
 
 class MQ135 {
  private:
   uint8_t _pin;
+  float RZero;
 
  public:
   MQ135(uint8_t pin);
@@ -50,6 +51,8 @@ class MQ135 {
   float getPPM();
   float getCorrectedPPM(float t, float h);
   float getRZero();
+  float getStoredRZero();
   float getCorrectedRZero(float t, float h);
+  void setRZero(float r);
 };
 #endif


### PR DESCRIPTION
Hello the formula for get corrected resistance is incorrect and should look like ....

_/
/_************************************************************************_/
float MQ135::getCorrectedRZero(float t, float h) {
  *_return getCorrectedResistance(t, h) \* pow((PARA/ATMOCO2), (1./PARB));**
}

/**************************************************************************/
